### PR TITLE
rn 0.56 ios compatibility

### DIFF
--- a/src/create-text-gradient-class.js
+++ b/src/create-text-gradient-class.js
@@ -14,7 +14,7 @@
 import * as React from 'react';
 import StyleSheetPropType from 'react-native/Libraries/StyleSheet/StyleSheetPropType';
 import ReactNativeViewAttributes from 'react-native/Libraries/Components/View/ReactNativeViewAttributes';
-import mergeFast from 'react-native/Libraries/Utilities/mergeFast';
+import mergeFast from './mergeFast';
 import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import TextStylePropTypes from 'react-native/Libraries/Text/TextStylePropTypes';

--- a/src/mergeFast.js
+++ b/src/mergeFast.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @providesModule mergeFast
+ * @flow
+ */
+'use strict';
+
+/**
+ * Faster version of `merge` that doesn't check its arguments and
+ * also merges prototype inherited properties.
+ *
+ * @param {object} one Any non-null object.
+ * @param {object} two Any non-null object.
+ * @return {object} Merging of two objects, including prototype
+ * inherited properties.
+ */
+var mergeFast = function(one: Object, two: Object): Object {
+  var ret = {};
+  for (var keyOne in one) {
+    ret[keyOne] = one[keyOne];
+  }
+  for (var keyTwo in two) {
+    ret[keyTwo] = two[keyTwo];
+  }
+  return ret;
+};
+
+module.exports = mergeFast;


### PR DESCRIPTION
`mergeFast` was deleted in https://github.com/facebook/react-native/commit/a1f2076aae13dd973932b0ecb90529402ab3f09f.

So I just copied the original file to this repository and imported it in `create-text-gradient-class.js`