### PR TITLE
fix path-rn.js for release build

### DIFF
--- a/patch-rn.js
+++ b/patch-rn.js
@@ -10,7 +10,7 @@ const pattern = new RegExp(
   'invariant\\([\\s\\S]{0,20}' +
   '(hostContext|type)\\.isInAParentText,[\\s\\S]{0,20}' +
   '"Text strings must be rendered within a <Text> component\\."[\\s\\S]{0,20}' +
-  '\\);'
+  '\\)[;,]'
 );
 
 const patchFile = async (file) => {


### PR DESCRIPTION
ReactNativeRender-prod.js
ReactNativeRender-profiling.js
have different form to check invariant:
              invariant(
                type.isInAParentText,
                "Text strings must be rendered within a <Text> component."
              ),